### PR TITLE
Update status.html

### DIFF
--- a/www.freecol.org/status.html
+++ b/www.freecol.org/status.html
@@ -74,7 +74,6 @@
                 <table class="contentpaneopen">
                     <tr>
                         <td valign="top" colspan="2">
-                            <p>The the current version of FreeCol is 0.11.6.</p>
                             <p>FreeCol is continuously developed. For more on the latest Freecol development progress, please visit the <a href="https://sourceforge.net/projects/freecol/" title="FreeCol on SourceForge">SourceForge Project page</a>.</p>
                         </td>
                     </tr>


### PR DESCRIPTION
Removed “The the current version of FreeCol is 0.11.6.” from the About FreeCol/Current Status section to future proof the page. The line below it about being in constant development and linking to sourceforge page is PERFECT on its own.